### PR TITLE
发布：收口 v1.0.0 版本

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## 使用者运行
 
-默认使用已发布 Docker 镜像：
+默认使用已发布 Docker 镜像 `ghcr.io/wodenwang/bpmt-lite:1.0.0`：
 
 ```bash
 docker compose up -d

--- a/dbtools/pom.xml
+++ b/dbtools/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>parent</artifactId>
 		<groupId>com.riversoft</groupId>
-		<version>3.4.1-SNAPSHOT</version>
+		<version>1.0.0</version>
 		<relativePath>../parent/</relativePath>
 	</parent>
 	<artifactId>dbtools</artifactId>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   web:
-    image: ghcr.io/wodenwang/bpmt-lite:${BPMT_IMAGE_TAG:-3.4.1-SNAPSHOT}
+    image: ghcr.io/wodenwang/bpmt-lite:${BPMT_IMAGE_TAG:-1.0.0}
     platform: linux/amd64
     container_name: bpmt-lite-web
     depends_on:

--- a/magic/magic-api-impl/pom.xml
+++ b/magic/magic-api-impl/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magic</artifactId>
     <groupId>com.riversoft</groupId>
-    <version>3.4.1-SNAPSHOT</version>
+    <version>1.0.0</version>
   </parent>
   <artifactId>magic-api-impl</artifactId>
   <name>RiverSoft Magic API Implementation</name>

--- a/magic/magic-api/pom.xml
+++ b/magic/magic-api/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>magic</artifactId>
     <groupId>com.riversoft</groupId>
-    <version>3.4.1-SNAPSHOT</version>
+    <version>1.0.0</version>
   </parent>
   <artifactId>magic-api</artifactId>
   <name>RiverSoft Magic API</name>

--- a/magic/pom.xml
+++ b/magic/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>parent</artifactId>
     <groupId>com.riversoft</groupId>
-    <version>3.4.1-SNAPSHOT</version>
+    <version>1.0.0</version>
 	<relativePath>../parent/</relativePath>
   </parent>
   <artifactId>magic</artifactId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.riversoft</groupId>
     <artifactId>riversoft-product</artifactId>
-    <version>3.4.1-SNAPSHOT</version>
+    <version>1.0.0</version>
   </parent>
 
   <properties>

--- a/platform/pom.xml
+++ b/platform/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>parent</artifactId>
     <groupId>com.riversoft</groupId>
-    <version>3.4.1-SNAPSHOT</version>
+    <version>1.0.0</version>
     <relativePath>../parent/</relativePath>
   </parent>
   <artifactId>platform</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.riversoft</groupId>
   <artifactId>riversoft-product</artifactId>
-  <version>3.4.1-SNAPSHOT</version>
+  <version>1.0.0</version>
   <packaging>pom</packaging>
   <name>RiverSoft Product</name>
 

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>parent</artifactId>
     <groupId>com.riversoft</groupId>
-    <version>3.4.1-SNAPSHOT</version>
+    <version>1.0.0</version>
     <relativePath>../parent/</relativePath>
   </parent>
   <artifactId>util</artifactId>


### PR DESCRIPTION
## 摘要
- 将 Maven 反应堆版本收口为 1.0.0
- 将 docker compose 默认镜像 tag 改为 1.0.0
- README 明确默认使用 ghcr.io/wodenwang/bpmt-lite:1.0.0

## 验证
- scripts/verify-repo.sh
- Java 8 Maven 编译：mvn -s settings.local.xml -pl platform -am -Pdocker-image -DskipTests compile
- scripts/build-image.sh
- 匿名拉取 ghcr.io/wodenwang/bpmt-lite:1.0.0 和 latest
- docker compose 使用 1.0.0 启动，ROOT 与 /ueditor/ 均返回 200