### PR TITLE
文档：补齐 v1.0.0 发布与维护说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,36 +4,117 @@
 
 本项目只调整代码结构、打包方式、配置方式和部署方式，不升级技术栈、不重写功能、不增加功能。运行栈继续保持 Java 8、Tomcat 7、MariaDB。
 
-## 使用者运行
+## v1.0.0 状态
 
-默认使用已发布 Docker 镜像 `ghcr.io/wodenwang/bpmt-lite:1.0.0`：
+`v1.0.0` 是 bpmt-lite 的首个正式 Docker 化版本。
 
-```bash
-docker compose up -d
-```
+- GitHub Release: https://github.com/wodenwang/bpmt-lite/releases/tag/v1.0.0
+- 默认 Web 镜像：`ghcr.io/wodenwang/bpmt-lite:1.0.0`
+- 同步镜像 tag：`ghcr.io/wodenwang/bpmt-lite:latest`
+- 默认 Web 访问地址：`http://127.0.0.1:8080/`
+- Tomcat 中的 `ROOT` 应用是 BPMT `platform`
+- Tomcat 中额外包含 `/ueditor` 应用
+- MariaDB 初始化数据库名：`kyq`
+- 发布验收：`kyq` 初始化后 383 张表，`/` 和 `/ueditor/` 均返回 200
 
-如果需要初始化干净数据库，将 `kyq.sql` 放到：
+## Quick Start
+
+只想把系统跑起来，按下面做。
+
+### 1. 准备文件
+
+确认本机已经安装 Docker Desktop 或 Docker Engine，并且可以运行 `docker compose`。
+
+把初始化数据库文件放到：
 
 ```text
 db/init/kyq.sql
 ```
 
-MariaDB 只会在首次创建 `db/data` 数据目录时自动导入该文件。数据库已经初始化后，替换 `kyq.sql` 不会自动重新导入。
+如果没有 `kyq.sql`，容器仍会启动，但不会得到完整的初始化业务数据。
+
+### 2. 启动
+
+```bash
+docker compose up -d
+```
+
+第一次启动会自动拉取镜像、启动 MariaDB、导入 `db/init/kyq.sql`。
+
+### 3. 访问
+
+```text
+http://127.0.0.1:8080/
+```
+
+UEditor 应用地址：
+
+```text
+http://127.0.0.1:8080/ueditor/
+```
+
+### 4. 查看状态
+
+```bash
+docker compose ps
+```
+
+看到 `bpmt-lite-mariadb` 是 `healthy`，`bpmt-lite-web` 是 `Up` 即可。
+
+### 5. 停止
+
+```bash
+docker compose down
+```
+
+该命令只停止并删除容器，不会删除 `db/data`、`runtime` 下的数据文件。
+
+## 重新初始化数据库
+
+MariaDB 只会在首次创建 `db/data` 数据目录时自动导入 `db/init/kyq.sql`。
+
+如果已经启动过，再替换 `kyq.sql` 不会自动重新导入。需要重新初始化时，先确认已经备份数据，然后删除本地数据目录：
+
+```bash
+docker compose down
+rm -rf db/data
+docker compose up -d
+```
+
+## 常用配置
+
+默认配置都写在 `docker-compose.yml` 中，可以直接通过环境变量修改常用项。
+
+| 配置 | 默认值 | 说明 |
+| --- | --- | --- |
+| `BPMT_HTTP_PORT` | `8080` | Web 访问端口 |
+| `BPMT_DB_PORT` | `3306` | MariaDB 暴露到宿主机的端口 |
+| `BPMT_IMAGE_TAG` | `1.0.0` | Web 镜像 tag |
+| `DB_HOST` | `mariadb` | Web 容器访问数据库的主机名 |
+| `DB_NAME` | `kyq` | 数据库名 |
+| `DB_USER` | `root` | 数据库用户 |
+| `DB_PASSWORD` | `123456` | 数据库密码 |
+
+示例：把 Web 端口改成 18080。
+
+```bash
+BPMT_HTTP_PORT=18080 docker compose up -d
+```
 
 ## 运行目录
 
 运行时目录约定如下：
 
 ```text
-db/init/kyq.sql        首次初始化数据库备份，不提交 git
-db/data/               MariaDB 数据目录，不提交 git
-db/logs/               MariaDB 日志目录，不提交 git
-runtime/attachment/    BPMT 附件目录，不提交 git
-runtime/download/      BPMT 下载目录，不提交 git
-runtime/ueditor-upload/ UEditor 上传目录，不提交 git
-runtime/platform-logs/ BPMT 平台日志目录，不提交 git
-runtime/tomcat-logs/   Tomcat 日志目录，不提交 git
-config/overrides/      properties 覆盖文件目录，不提交具体覆盖文件
+db/init/kyq.sql          首次初始化数据库备份，不提交 git
+db/data/                 MariaDB 数据目录，不提交 git
+db/logs/                 MariaDB 日志目录，不提交 git
+runtime/attachment/      BPMT 附件目录，不提交 git
+runtime/download/        BPMT 下载目录，不提交 git
+runtime/ueditor-upload/  UEditor 上传目录，不提交 git
+runtime/platform-logs/   BPMT 平台日志目录，不提交 git
+runtime/tomcat-logs/     Tomcat 日志目录，不提交 git
+config/overrides/        properties 覆盖文件目录，不提交具体覆盖文件
 ```
 
 `config/overrides/*.properties` 会追加到容器启动时生成的同名 properties 文件后面，因此覆盖文件中的同名 key 优先级更高。
@@ -48,6 +129,8 @@ scripts/build-image.sh
 ```
 
 `settings.local.xml` 不提交到 git。
+
+更多维护和发布细节见 [docs/maintenance.md](docs/maintenance.md)。
 
 ## 项目语言
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -1,0 +1,219 @@
+# bpmt-lite 维护说明
+
+本文面向维护者，记录本项目的构建、验证、发布和常见处理方式。
+
+## 基本原则
+
+- 项目沟通和文档使用简体中文
+- 保留 Java 8、Tomcat 7、MariaDB
+- 不为工程整理主动升级底层技术栈
+- 不做功能扩展，除非有明确版本目标
+- 不提交本地运行数据、数据库备份、私有依赖和许可证文件
+
+## 本地前置条件
+
+维护构建需要：
+
+- Java 8
+- Maven
+- Docker
+- 可访问旧私有依赖的 Maven 配置
+- GitHub/GHCR 发布权限
+
+确认 Java 版本：
+
+```bash
+java -version
+```
+
+如果机器上有多个 JDK，构建时显式指定 Java 8：
+
+```bash
+JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-1.8.jdk/Contents/Home \
+PATH=/Library/Java/JavaVirtualMachines/jdk-1.8.jdk/Contents/Home/bin:$PATH \
+mvn -s settings.local.xml -pl platform -am -Pdocker-image -DskipTests compile
+```
+
+## Maven 配置
+
+首次构建前复制本地配置：
+
+```bash
+cp settings.example.xml settings.local.xml
+```
+
+`settings.local.xml` 不提交到 git。它用于配置可访问旧私有依赖的 Maven 仓库。
+
+当前仍可能依赖旧包，例如 Aspose、JPedal、patch implementation、UEditor WAR 等。不要在没有专项计划的情况下替换这些依赖。
+
+## 仓库检查
+
+提交前运行：
+
+```bash
+scripts/verify-repo.sh
+```
+
+该脚本会检查：
+
+- 必要模块存在
+- 旧发行相关模块没有迁入
+- 本地运行数据没有进入 git
+- 私有依赖、许可证、数据库备份没有进入 git
+- origin 指向 `https://github.com/wodenwang/bpmt-lite.git`
+
+## 构建镜像
+
+使用：
+
+```bash
+scripts/build-image.sh
+```
+
+脚本会：
+
+- 检查 `settings.local.xml`
+- 检查当前 Java 是否为 Java 8
+- 执行 Maven `-Pdocker-image verify`
+- 构建 `ghcr.io/wodenwang/bpmt-lite:<project.version>`
+
+## 本地运行验证
+
+准备数据库初始化文件：
+
+```text
+db/init/kyq.sql
+```
+
+启动：
+
+```bash
+docker compose up -d
+```
+
+检查状态：
+
+```bash
+docker compose ps
+```
+
+检查数据库表数量：
+
+```bash
+docker compose exec -T mariadb mariadb -uroot -p123456 -N \
+  -e "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='kyq';"
+```
+
+`v1.0.0` 的期望结果是 `383`。
+
+检查 Web：
+
+```bash
+curl -fsSI http://127.0.0.1:8080/
+curl -fsSI http://127.0.0.1:8080/ueditor/
+```
+
+期望均返回 `HTTP/1.1 200 OK`。
+
+## 发布流程
+
+正式发布建议按以下顺序：
+
+1. 新建发布分支
+2. 修改 Maven 版本号
+3. 修改 `docker-compose.yml` 默认 `BPMT_IMAGE_TAG`
+4. 更新 README 和 release 文档
+5. 运行 `scripts/verify-repo.sh`
+6. 使用 Java 8 编译
+7. 执行 `scripts/build-image.sh`
+8. 推送 GHCR 镜像
+9. 匿名拉取镜像验证
+10. 基于 tag 或干净克隆运行 compose 验证
+11. 合并 PR 到 `main`
+12. 在合并后的 `main` 打 git tag
+13. 创建 GitHub Release
+
+## GHCR 发布
+
+登录 GHCR：
+
+```bash
+gh auth token | docker login ghcr.io -u wodenwang --password-stdin
+```
+
+推送镜像：
+
+```bash
+docker push ghcr.io/wodenwang/bpmt-lite:<tag>
+```
+
+匿名拉取验证：
+
+```bash
+TMP_DOCKER_CONFIG=$(mktemp -d)
+DOCKER_CONFIG="$TMP_DOCKER_CONFIG" docker pull --platform linux/amd64 ghcr.io/wodenwang/bpmt-lite:<tag>
+rm -rf "$TMP_DOCKER_CONFIG"
+```
+
+查看 digest：
+
+```bash
+crane digest ghcr.io/wodenwang/bpmt-lite:<tag>
+```
+
+本机曾出现 Docker push 到 GHCR 大层断流。如果新构建镜像与已验证镜像运行内容一致，可以使用 registry 级别重标记作为发布补救方案：
+
+```bash
+crane copy ghcr.io/wodenwang/bpmt-lite:<source-tag> ghcr.io/wodenwang/bpmt-lite:<target-tag>
+```
+
+`v1.0.0` 发布时，`1.0.0` 和 `latest` 都重标记到已验证 digest：
+
+```text
+sha256:8d3071c2b43e472beb0f453990b95c057895bf02bdd4be0dcdf74e7b336ba961
+```
+
+使用该方案前必须确认运行内容没有实质差异，并完成 compose 验收。
+
+## 数据和目录
+
+不要提交以下内容：
+
+- `db/init/*.sql`
+- `db/data/`
+- `db/logs/`
+- `runtime/`
+- `config/overrides/*.properties`
+- `settings.local.xml`
+- 私有依赖 jar、war
+- 许可证文件
+
+`db/init/kyq.sql` 只用于首次初始化。已有 `db/data` 时不会再次导入。
+
+## 常见问题
+
+### 修改 kyq.sql 后为什么没有重新导入？
+
+MariaDB 官方初始化机制只在数据目录为空时执行 `/docker-entrypoint-initdb.d`。需要重新导入时，先备份数据，再删除 `db/data` 后重启。
+
+### 为什么不升级 Java、Tomcat、Spring 或 MariaDB？
+
+本项目目标是发行方式现代化，不是技术栈升级。老技术栈虽然陈旧，但业务功能已经稳定；贸然升级会带来较高回归风险。
+
+### 为什么有些配置在 docker-compose.yml 里很多？
+
+这是为了让原 properties 中的关键配置可以通过 compose 管理，而不是进入 Docker image 内部修改。
+
+### UEditor 上传文件保存在哪里？
+
+容器内路径：
+
+```text
+/usr/local/tomcat/webapps/ueditor/upload
+```
+
+宿主机映射路径：
+
+```text
+runtime/ueditor-upload
+```

--- a/docs/release-v1.0.0.md
+++ b/docs/release-v1.0.0.md
@@ -1,0 +1,102 @@
+# bpmt-lite v1.0.0 发布说明
+
+`v1.0.0` 是 bpmt-lite 的首个正式版本，目标是把原 BPMT 核心 Web 服务整理为更简洁的 Docker 化发行工程。
+
+## 发布结论
+
+- Git tag: `v1.0.0`
+- GitHub Release: https://github.com/wodenwang/bpmt-lite/releases/tag/v1.0.0
+- 默认 Web 镜像：`ghcr.io/wodenwang/bpmt-lite:1.0.0`
+- 同步镜像：`ghcr.io/wodenwang/bpmt-lite:latest`
+- 数据库镜像：`mariadb:10.11`
+- 默认数据库名：`kyq`
+- 默认 Web 端口：`8080`
+- 默认数据库端口：`3306`
+
+## 范围
+
+本版本只做工程结构和发行方式收口：
+
+- 保留 Java 8、Tomcat 7、MariaDB 技术栈
+- 保留原 `platform` 核心 Web 功能
+- Tomcat `ROOT` 应用为 `platform`
+- Tomcat 额外部署 `/ueditor` 应用
+- 使用 `docker compose` 管理 Web 和 MariaDB 两个实例
+- 使用宿主机目录挂载附件、下载文件、UEditor 上传文件、平台日志、Tomcat 日志、MariaDB 数据和 MariaDB 日志
+- 通过 compose 环境变量暴露原 properties 中的主要配置项
+
+本版本不包含：
+
+- Java、Spring、Tomcat、MariaDB 技术升级
+- 业务功能重写
+- 新功能扩展
+- 私有旧依赖的替换方案
+
+## 快速启动
+
+把初始化 SQL 放到：
+
+```text
+db/init/kyq.sql
+```
+
+启动：
+
+```bash
+docker compose up -d
+```
+
+访问：
+
+```text
+http://127.0.0.1:8080/
+```
+
+UEditor：
+
+```text
+http://127.0.0.1:8080/ueditor/
+```
+
+## 运行目录
+
+| 目录 | 用途 |
+| --- | --- |
+| `db/init/kyq.sql` | 首次初始化数据库备份 |
+| `db/data/` | MariaDB 数据目录 |
+| `db/logs/` | MariaDB 日志目录 |
+| `runtime/attachment/` | BPMT 附件目录 |
+| `runtime/download/` | BPMT 下载目录 |
+| `runtime/ueditor-upload/` | UEditor 上传目录 |
+| `runtime/platform-logs/` | BPMT 平台日志目录 |
+| `runtime/tomcat-logs/` | Tomcat 日志目录 |
+| `config/overrides/` | properties 覆盖文件目录 |
+
+## 验收结果
+
+发布前已完成以下验证：
+
+- `scripts/verify-repo.sh` 通过
+- Java 8 Maven 编译通过
+- `scripts/build-image.sh` 本地构建通过
+- 匿名拉取 `ghcr.io/wodenwang/bpmt-lite:1.0.0` 通过
+- 匿名拉取 `ghcr.io/wodenwang/bpmt-lite:latest` 通过
+- 基于 `v1.0.0` tag 干净克隆启动通过
+- `kyq` 初始化后表数量为 `383`
+- `/` 返回 `200`
+- `/ueditor/` 返回 `200`
+
+## 已知限制
+
+- `kyq.sql` 不提交到 git，需要部署者自行放入 `db/init/kyq.sql`
+- MariaDB 只会在首次创建 `db/data` 时导入 `db/init/kyq.sql`
+- 如果已经初始化过数据库，替换 `kyq.sql` 不会自动重新导入
+- Web 镜像仍基于 Tomcat 7 和 Java 8，属于兼容性保留，不代表推荐新项目继续使用该技术栈
+- 项目仍依赖部分旧私有 Maven 包，维护者构建时需要可访问旧依赖仓库
+- `1.0.0` 和 `latest` 镜像 tag 指向已验证 digest：`sha256:8d3071c2b43e472beb0f453990b95c057895bf02bdd4be0dcdf74e7b336ba961`
+
+## GHCR 说明
+
+正式收口时，本机到 GHCR 的大层上传链路多次断流。最终发布采用 registry 级别重标记：将已公开、已完整验证的镜像 digest 发布为 `1.0.0` 和 `latest`。
+
+该处理不改变运行内容。发布前已对镜像运行内容和 compose 启动结果做验收。


### PR DESCRIPTION
## 摘要
- 重写 README，增加 v1.0.0 状态摘要和傻瓜化 Quick Start
- 新增 docs/release-v1.0.0.md，记录 v1.0.0 发布结论、范围、验收和已知限制
- 新增 docs/maintenance.md，记录维护者构建、验证、发布和 GHCR 断流处理方式

## 验证
- scripts/verify-repo.sh
- docker compose config