### PR TITLE
Add Docker image publish workflow

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -1,0 +1,54 @@
+name: Publish Docker Images
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: Web/API image tag to publish
+        required: true
+        default: 1.8.1
+      sync_latest:
+        description: Also publish latest tags
+        required: true
+        default: "true"
+        type: choice
+        options:
+          - "true"
+          - "false"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "8"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare Maven settings
+        run: cp settings.example.xml settings.local.xml
+
+      - name: Build and publish multi-arch images
+        env:
+          BPMT_IMAGE_TAG: ${{ inputs.image_tag }}
+          BPMT_API_IMAGE_TAG: ${{ inputs.image_tag }}
+          BPMT_SYNC_LATEST: ${{ inputs.sync_latest }}
+        run: scripts/build-multiarch-images.sh


### PR DESCRIPTION
## 变更范围

- 新增手动触发的 GHCR multi-arch 镜像发布 workflow。
- 使用 Java 8、Docker Buildx 和仓库内 scripts/build-multiarch-images.sh 发布 Web/API 镜像。

## 原因

本机到 GHCR 的 buildx/docker push 在 layer 上传阶段长时间卡住；改由 GitHub Actions 在 GitHub 侧完成正式镜像发布。

## 验证

- git diff --check
