### PR TITLE
Use GHCR token for image publish workflow

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -40,8 +40,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_TOKEN }}
 
       - name: Prepare Maven settings
         run: cp settings.example.xml settings.local.xml


### PR DESCRIPTION
## 变更范围

- Docker image publish workflow 改为使用仓库 secret GHCR_TOKEN 登录 GHCR。

## 原因

Publish Docker Images run 27467115574 已完成构建，但 push GHCR 时 GITHUB_TOKEN 被现有 package 拒绝 write_package。本仓已配置 GHCR_TOKEN secret，用于正式镜像发布。

## 验证

- git diff --check
- gh secret list 确认 GHCR_TOKEN 已存在
